### PR TITLE
コミュニティおよびユーザー関係の table を追加

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,2 +1,3 @@
 class Article < ApplicationRecord
+  belongs_to :user
 end

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -1,0 +1,2 @@
+class Community < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,8 @@
 class User < ApplicationRecord
   validates :account, presence: true, uniqueness: { case_sensitive: false }
+  has_many :articles
+  has_one :user_detail
+
+  has_many :user_communities
+  has_many :communities, through: :user_communities
 end

--- a/app/models/user_community.rb
+++ b/app/models/user_community.rb
@@ -1,0 +1,4 @@
+class UserCommunity < ApplicationRecord
+  belongs_to :user
+  belongs_to :community
+end

--- a/app/models/user_detail.rb
+++ b/app/models/user_detail.rb
@@ -1,0 +1,3 @@
+class UserDetail < ApplicationRecord
+  belongs_to :user
+end

--- a/db/migrate/20220416140946_add_user_id_to_articles.rb
+++ b/db/migrate/20220416140946_add_user_id_to_articles.rb
@@ -1,0 +1,5 @@
+class AddUserIdToArticles < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :articles, :user, foreign_key: true
+  end
+end

--- a/db/migrate/20220416142234_create_user_details.rb
+++ b/db/migrate/20220416142234_create_user_details.rb
@@ -1,0 +1,11 @@
+class CreateUserDetails < ActiveRecord::Migration[6.0]
+  def change
+    create_table :user_details do |t|
+      t.datetime :birthday
+      t.string :phone_number
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220418144734_create_communities.rb
+++ b/db/migrate/20220418144734_create_communities.rb
@@ -1,0 +1,9 @@
+class CreateCommunities < ActiveRecord::Migration[6.0]
+  def change
+    create_table :communities do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220418145237_create_user_communities.rb
+++ b/db/migrate/20220418145237_create_user_communities.rb
@@ -1,0 +1,10 @@
+class CreateUserCommunities < ActiveRecord::Migration[6.0]
+  def change
+    create_table :user_communities do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :community, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,39 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_01_151354) do
+ActiveRecord::Schema.define(version: 2022_04_18_145237) do
 
   create_table "articles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.string "title"
     t.text "body"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_articles_on_user_id"
+  end
+
+  create_table "communities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "user_communities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "community_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["community_id"], name: "index_user_communities_on_community_id"
+    t.index ["user_id"], name: "index_user_communities_on_user_id"
+  end
+
+  create_table "user_details", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+    t.datetime "birthday"
+    t.string "phone_number"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_user_details_on_user_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
@@ -27,4 +53,8 @@ ActiveRecord::Schema.define(version: 2022_04_01_151354) do
     t.string "email"
   end
 
+  add_foreign_key "articles", "users"
+  add_foreign_key "user_communities", "communities"
+  add_foreign_key "user_communities", "users"
+  add_foreign_key "user_details", "users"
 end


### PR DESCRIPTION
# 概要
- 変更の概要
- 1:多、1対1, 多対多のテーブル設計

# 実行コマンド
- bundle exec rails g migration AddUserIdToArticles user:references
- rails db:migrate
- bundle exec rails c

# やったこと
- このプルリクで何をしたのか？（あれば。無いなら「無し」でOK） (やらない場合はいつやるのか明記する。)
- ユーザーの電話番号や誕生日等、詳細情報の追記
- userからcommunityへ情報を取得する際に中間テーブルを持たせてた。

# できるようになること（ユーザ目線）
- 何ができるようになるのか？（あれば。無いなら「無し」でOK）
- 外部の情報取得や関連の情報を紐付けできるようになる。

# できなくなること（ユーザ目線）
- 特になし

# 動作確認
- どのような動作確認を行ったのか？　結果はどうか？
- sequel pro に情報に外部キーで紐付けされいる事を確認した。

# その他
- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）